### PR TITLE
Add type alias to improve legibility of derived readerT instance

### DIFF
--- a/core/src/main/scala/com/dwolla/util/async/package.scala
+++ b/core/src/main/scala/com/dwolla/util/async/package.scala
@@ -1,5 +1,8 @@
 package com.dwolla.util
 
+import cats.data.ReaderT
+
 package object async {
   type ~~>[F[_], G[_]] = AsyncFunctorK[F, G]
+  type AlgReaderT[F[_], Alg[_[_]]] = Alg[ReaderT[F, Alg[F], *]]
 }

--- a/examples/src/main/scala/FooService.scala
+++ b/examples/src/main/scala/FooService.scala
@@ -1,6 +1,6 @@
-import cats.data._
 import cats.effect._
 import cats.tagless._
+import com.dwolla.util.async.AlgReaderT
 import com.dwolla.util.async.stdlib._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,7 +10,7 @@ trait FooService[F[_]] {
 }
 
 object FooService {
-  implicit def FooServiceReaderT[F[_]]: FooService[ReaderT[F, FooService[F], *]] =
+  implicit def FooServiceReaderT[F[_]]: AlgReaderT[F, FooService] =
     Derive.readerT[FooService, F]
   implicit val FooServiceFunctorK: FunctorK[FooService] = Derive.functorK
 }


### PR DESCRIPTION
long service names make the type signature unmanageable