### PR TITLE
update AdaptHigherKindedThriftCode rule to handle renamed imports

### DIFF
--- a/scalafix/input/src/main/scala/example/dwolla/ThriftServiceRenamedOnImport.scala
+++ b/scalafix/input/src/main/scala/example/dwolla/ThriftServiceRenamedOnImport.scala
@@ -1,0 +1,9 @@
+/*rule = AdaptHigherKindedThriftCode*/
+package example.dwolla
+
+import cats.tagless.FunctorK
+import example.foo.{FooService => TFooService}
+
+class ThriftServiceRenamedOnImport[F[_]](val fooService: TFooService[F]) {
+  implicitly[FunctorK[TFooService]]
+}

--- a/scalafix/input/src/main/scala/example/dwolla/ThriftServiceTypeAlias.scala
+++ b/scalafix/input/src/main/scala/example/dwolla/ThriftServiceTypeAlias.scala
@@ -1,0 +1,14 @@
+/*rule = AdaptHigherKindedThriftCode*/
+package example.dwolla
+
+import cats.tagless.FunctorK
+import example.dwolla.ThriftServiceTypeAlias.TFooService
+import example.foo.FooService
+
+object ThriftServiceTypeAlias {
+  type TFooService[F[_]] = FooService[F]
+}
+
+class ThriftServiceTypeAlias[F[_]](val fooService: TFooService[F]) {
+  implicitly[FunctorK[TFooService]]
+}

--- a/scalafix/output/src/main/scala/example/dwolla/ThriftServiceRenamedOnImport.scala
+++ b/scalafix/output/src/main/scala/example/dwolla/ThriftServiceRenamedOnImport.scala
@@ -1,0 +1,8 @@
+package example.dwolla
+
+import cats.tagless.FunctorK
+import example.foo.{FooService => TFooService}
+
+class ThriftServiceRenamedOnImport[F[_]](val fooService: TFooService.FooService[F]) {
+  implicitly[FunctorK[TFooService.FooService]]
+}

--- a/scalafix/output/src/main/scala/example/dwolla/ThriftServiceTypeAlias.scala
+++ b/scalafix/output/src/main/scala/example/dwolla/ThriftServiceTypeAlias.scala
@@ -1,0 +1,13 @@
+package example.dwolla
+
+import cats.tagless.FunctorK
+import example.dwolla.ThriftServiceTypeAlias.TFooService
+import example.foo.FooService
+
+object ThriftServiceTypeAlias {
+  type TFooService[F[_]] = FooService.FooService[F]
+}
+
+class ThriftServiceTypeAlias[F[_]](val fooService: TFooService[F]) {
+  implicitly[FunctorK[TFooService]]
+}

--- a/scalafix/rules/src/main/scala/com/dwolla/scrooge/scalafix/AdaptHigherKindedThriftCode.scala
+++ b/scalafix/rules/src/main/scala/com/dwolla/scrooge/scalafix/AdaptHigherKindedThriftCode.scala
@@ -43,7 +43,7 @@ object AdaptHigherKindedThriftCode {
                                              (implicit doc: SemanticDocument): Patch =
     tree.collect {
       case t@Type.Name(name) if isGeneratedThriftService(t) =>
-        Patch.addLeft(t, s"$name.")
+        Patch.replaceTree(t, s"$name.${t.symbol.normalized.displayName}")
     }
       .fold(Patch.empty)(_ + _)
 }


### PR DESCRIPTION
Code like this was not being adapted correctly, so manual intervention was required:

```scala
import example.foo.{FooService => TFooService}

class ThriftServiceRenamedOnImport[F[_]](val fooService: TFooService[F]) {
  implicitly[FunctorK[TFooService]]
}
```

The `TFooService[F]` types were being rewritten to `TFooService.TFooService[F]`, which is wrong, since the second `TFooService` isn't renamed by the import.

This PR should fix that issue, so that the rewrite rule does the right thing:

```scala
import example.foo.{FooService => TFooService}

class ThriftServiceRenamedOnImport[F[_]](val fooService: TFooService.FooService[F]) {
  implicitly[FunctorK[TFooService.FooService]]
}
```