### PR TITLE
let Scala Steward update PRs that get behind the base branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,16 +13,10 @@ pull_request_rules:
         users: [bpholt]
       label:
         add: [dependency-update]
-  - name: automatic update pull requests
-    conditions:
-      - author=scala-steward
-      - -conflict # skip PRs with conflicts
-      - -draft # filter-out GH draft PRs
-    actions:
-      update:
   - name: merge scala-steward's PRs
     conditions:
       - author=scala-steward
+      - "#commits-behind=0"
       - status-success=Build and Test (ubuntu-latest, temurin@8)
       - status-success=Build and Test (ubuntu-latest, temurin@11)
     actions:

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updatePullRequests = always


### PR DESCRIPTION
Before, Mergify would merge the base branch back into the PR. This works whenever there is no merge conflict, but once a conflict develops (which is not uncommon in practice), Scala Steward sees the Mergify merge commits as a user change to the PR, and declines to further update it. This meant the merge conflict had to be resolved manually, which then meant that the pull request has to be approved by someone other than the person who resolved the conflict (due to Dwolla's PR review policies).

Hopefully with this change, Scala Steward will be able to keep its PRs up to date itself, and it will know how to resolve most merge conflicts that come up. The downside is that Scala Steward might not be as fast to update PRs as Mergify was, so it might take a little longer for the PRs to be merged. We'll see.