### PR TITLE
Discover node executable with nvm

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen


### PR DESCRIPTION
This lets me run the test suite in the sbt console in IntelliJ. (AFAICT IntelliJ doesn't let you set a `PATH` environment variable to override how `node` is resolved, and I don't want to install a global Node instance, since the version being used can vary from project to project.)